### PR TITLE
Update packages version

### DIFF
--- a/sbi_lens/normflow/models.py
+++ b/sbi_lens/normflow/models.py
@@ -119,8 +119,11 @@ class ConditionalRealNVP(hk.Module):
         for i in range(self.n_layer)
     ])
 
-    nvp = tfd.TransformedDistribution(tfd.MultivariateNormalDiag(
-        0.5 * jnp.ones(self.d), scale_identity_multiplier=0.05),
-                                      bijector=chain)
+    nvp = tfd.TransformedDistribution(
+      tfd.MultivariateNormalDiag(
+        0.5 * jnp.ones(self.d),
+        0.05 * jnp.ones(self.d)),
+      bijector=chain
+    )
 
     return nvp

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,14 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        'numpy>=1.19.2', 'jax>=0.2.0', 'tensorflow_probability>=0.14.1',
-        'scikit-learn>=0.21', 'dm-haiku==0.0.5', 'jaxopt>=0.2',
-        'numpyro==0.10.1', 'jax-cosmo>=0.1.0', 'lenstools>=1.2',
+        'numpy>=1.19.2',
+        'jax>=0.2.0',
+        'tensorflow_probability>=0.14.1',
+        'dm-haiku>=0.0.5',
+        'jaxopt>=0.2',
+        'numpyro>=0.10.1',
+        'jax-cosmo>=0.1.0',
+        'lenstools>=1.2',
         'typing_extensions>=4.4.0'
     ],
 )


### PR DESCRIPTION
I updated  packages version + in the last tfp version they remove the `scale_identity_multiplier` used in our  [smooth flow](https://github.com/DifferentiableUniverseInitiative/sbi_lens/blob/6d7997fc8a843b7a5cde36e82d24c95349523d6f/sbi_lens/normflow/models.py#L123), I changed this part of the code so we don't have to work with restrictive tfp version